### PR TITLE
Force integration tests to produce a main jar

### DIFF
--- a/drift-integration-tests/src/main/resources/README.txt
+++ b/drift-integration-tests/src/main/resources/README.txt
@@ -1,0 +1,3 @@
+This jar is intentionally empty.
+
+OSS Nexus requires that a main jar exist in order to do a release.


### PR DESCRIPTION
OSS Nexus requires that a main jar exist in order to do a release.