### PR TITLE
Rename Runtime exceptions to Unchecked

### DIFF
--- a/drift-client/src/main/java/io/airlift/drift/client/DriftInvocationHandler.java
+++ b/drift-client/src/main/java/io/airlift/drift/client/DriftInvocationHandler.java
@@ -114,19 +114,19 @@ class DriftInvocationHandler
             }
 
             if (e instanceof TApplicationException) {
-                throw new RuntimeTApplicationException((TApplicationException) e);
+                throw new UncheckedTApplicationException((TApplicationException) e);
             }
 
             if (e instanceof TProtocolException) {
-                throw new RuntimeTProtocolException((TProtocolException) e);
+                throw new UncheckedTProtocolException((TProtocolException) e);
             }
 
             if (e instanceof TTransportException) {
-                throw new RuntimeTTransportException((TTransportException) e);
+                throw new UncheckedTTransportException((TTransportException) e);
             }
 
             if (e instanceof TException) {
-                throw new RuntimeTException((TException) e);
+                throw new UncheckedTException((TException) e);
             }
 
             TException wrappedException;
@@ -141,7 +141,7 @@ class DriftInvocationHandler
             if (canThrowTException) {
                 throw wrappedException;
             }
-            throw new RuntimeTException(wrappedException);
+            throw new UncheckedTException(wrappedException);
         }
     }
 

--- a/drift-client/src/main/java/io/airlift/drift/client/UncheckedTApplicationException.java
+++ b/drift-client/src/main/java/io/airlift/drift/client/UncheckedTApplicationException.java
@@ -15,18 +15,18 @@
  */
 package io.airlift.drift.client;
 
-import io.airlift.drift.protocol.TProtocolException;
+import io.airlift.drift.TApplicationException;
 
 /**
- * Runtime equivalent of TProtocolException.  If a Drift client receives a
- * TProtocolException for a method that doesn't declare TProtocolException
- * to be thrown, the underlying exception is wrapped in this class and
- * rethrown.
+ * Wraps a {@link TApplicationException} with an unchecked exception.
+ * If a Drift client receives a TApplicationException for a method
+ * that doesn't declare TApplicationException to be thrown,
+ * the underlying exception is wrapped in this class and rethrown.
  */
-public class RuntimeTProtocolException
-        extends RuntimeTException
+public class UncheckedTApplicationException
+        extends UncheckedTException
 {
-    public RuntimeTProtocolException(TProtocolException cause)
+    public UncheckedTApplicationException(TApplicationException cause)
     {
         super(cause);
     }

--- a/drift-client/src/main/java/io/airlift/drift/client/UncheckedTException.java
+++ b/drift-client/src/main/java/io/airlift/drift/client/UncheckedTException.java
@@ -15,19 +15,20 @@
  */
 package io.airlift.drift.client;
 
-import io.airlift.drift.protocol.TTransportException;
+import io.airlift.drift.TException;
+
+import static java.util.Objects.requireNonNull;
 
 /**
- * Runtime equivalent of TTransportException.  If a Drift client receives a
- * TTransportException for a method that doesn't declare TTransportException
- * to be thrown, the underlying exception is wrapped in this class and
- * rethrown.
+ * Wraps a {@link TException} with an unchecked exception. If a Drift client
+ * receives a TException for a method that doesn't declare TException to be
+ * thrown, the underlying exception is wrapped in this class and rethrown.
  */
-public class RuntimeTTransportException
-        extends RuntimeTException
+public class UncheckedTException
+        extends RuntimeException
 {
-    public RuntimeTTransportException(TTransportException cause)
+    public UncheckedTException(TException cause)
     {
-        super(cause);
+        super(requireNonNull(cause, "cause is null").getMessage(), cause);
     }
 }

--- a/drift-client/src/main/java/io/airlift/drift/client/UncheckedTProtocolException.java
+++ b/drift-client/src/main/java/io/airlift/drift/client/UncheckedTProtocolException.java
@@ -15,20 +15,19 @@
  */
 package io.airlift.drift.client;
 
-import io.airlift.drift.TException;
-
-import static java.util.Objects.requireNonNull;
+import io.airlift.drift.protocol.TProtocolException;
 
 /**
- * Runtime equivalent of TException.  If a Drift client receives a TException
- * for a method that doesn't declare TException to be thrown, the underlying
- * exception is wrapped in this class and rethrown.
+ * Wraps a {@link TProtocolException} with an unchecked exception.
+ * If a Drift client receives a TProtocolException for a method
+ * that doesn't declare TProtocolException to be thrown,
+ * the underlying exception is wrapped in this class and rethrown.
  */
-public class RuntimeTException
-        extends RuntimeException
+public class UncheckedTProtocolException
+        extends UncheckedTException
 {
-    public RuntimeTException(TException cause)
+    public UncheckedTProtocolException(TProtocolException cause)
     {
-        super(requireNonNull(cause, "cause is null").getMessage(), cause);
+        super(cause);
     }
 }

--- a/drift-client/src/main/java/io/airlift/drift/client/UncheckedTTransportException.java
+++ b/drift-client/src/main/java/io/airlift/drift/client/UncheckedTTransportException.java
@@ -15,18 +15,18 @@
  */
 package io.airlift.drift.client;
 
-import io.airlift.drift.TApplicationException;
+import io.airlift.drift.protocol.TTransportException;
 
 /**
- * Runtime equivalent of TApplicationException.  If a Drift client receives a
- * TApplicationException for a method that doesn't declare
- * TApplicationException to be thrown, the underlying exception is wrapped in
- * this class and rethrown.
+ * Wraps a {@link TTransportException} with an unchecked exception.
+ * If a Drift client receives a TTransportException for a method
+ * that doesn't declare TTransportException to be thrown,
+ * the underlying exception is wrapped in this class and rethrown.
  */
-public class RuntimeTApplicationException
-        extends RuntimeTException
+public class UncheckedTTransportException
+        extends UncheckedTException
 {
-    public RuntimeTApplicationException(TApplicationException cause)
+    public UncheckedTTransportException(TTransportException cause)
     {
         super(cause);
     }

--- a/drift-client/src/test/java/io/airlift/drift/client/TestDriftClient.java
+++ b/drift-client/src/test/java/io/airlift/drift/client/TestDriftClient.java
@@ -320,21 +320,21 @@ public class TestDriftClient
 
         // test method does not throw TException
         assertNoTExceptionInvocation(resultsSupplier, targets, statsFactory, classifiers, client, empty, new ClientException());
-        assertNoTExceptionInvocation(resultsSupplier, targets, statsFactory, classifiers, client, empty, new TException(), RuntimeTException.class);
-        assertNoTExceptionInvocation(resultsSupplier, targets, statsFactory, classifiers, client, empty, new TApplicationException(), RuntimeTApplicationException.class);
-        assertNoTExceptionInvocation(resultsSupplier, targets, statsFactory, classifiers, client, empty, new TTransportException(), RuntimeTTransportException.class);
-        assertNoTExceptionInvocation(resultsSupplier, targets, statsFactory, classifiers, client, empty, new TProtocolException(), RuntimeTProtocolException.class);
+        assertNoTExceptionInvocation(resultsSupplier, targets, statsFactory, classifiers, client, empty, new TException(), UncheckedTException.class);
+        assertNoTExceptionInvocation(resultsSupplier, targets, statsFactory, classifiers, client, empty, new TApplicationException(), UncheckedTApplicationException.class);
+        assertNoTExceptionInvocation(resultsSupplier, targets, statsFactory, classifiers, client, empty, new TTransportException(), UncheckedTTransportException.class);
+        assertNoTExceptionInvocation(resultsSupplier, targets, statsFactory, classifiers, client, empty, new TProtocolException(), UncheckedTProtocolException.class);
         assertNoTExceptionInvocation(resultsSupplier, targets, statsFactory, classifiers, client, empty, new Error());
-        assertNoTExceptionInvocation(resultsSupplier, targets, statsFactory, classifiers, client, empty, new UnknownException(), RuntimeTException.class, TException.class);
-        assertNoTExceptionInvocation(resultsSupplier, targets, statsFactory, classifiers, client, empty, new RuntimeException(), RuntimeTException.class, TException.class);
-        assertNoTExceptionInvocation(resultsSupplier, targets, statsFactory, classifiers, client, empty, new InterruptedException(), RuntimeTException.class, TException.class);
+        assertNoTExceptionInvocation(resultsSupplier, targets, statsFactory, classifiers, client, empty, new UnknownException(), UncheckedTException.class, TException.class);
+        assertNoTExceptionInvocation(resultsSupplier, targets, statsFactory, classifiers, client, empty, new RuntimeException(), UncheckedTException.class, TException.class);
+        assertNoTExceptionInvocation(resultsSupplier, targets, statsFactory, classifiers, client, empty, new InterruptedException(), UncheckedTException.class, TException.class);
 
         // custom exception subclasses
         assertNoTExceptionInvocation(resultsSupplier, targets, statsFactory, classifiers, client, empty, new ClientException() {});
-        assertNoTExceptionInvocation(resultsSupplier, targets, statsFactory, classifiers, client, empty, new TException() {}, RuntimeTException.class);
-        assertNoTExceptionInvocation(resultsSupplier, targets, statsFactory, classifiers, client, empty, new TApplicationException() {}, RuntimeTApplicationException.class);
-        assertNoTExceptionInvocation(resultsSupplier, targets, statsFactory, classifiers, client, empty, new TTransportException() {}, RuntimeTTransportException.class);
-        assertNoTExceptionInvocation(resultsSupplier, targets, statsFactory, classifiers, client, empty, new TProtocolException() {}, RuntimeTProtocolException.class);
+        assertNoTExceptionInvocation(resultsSupplier, targets, statsFactory, classifiers, client, empty, new TException() {}, UncheckedTException.class);
+        assertNoTExceptionInvocation(resultsSupplier, targets, statsFactory, classifiers, client, empty, new TApplicationException() {}, UncheckedTApplicationException.class);
+        assertNoTExceptionInvocation(resultsSupplier, targets, statsFactory, classifiers, client, empty, new TTransportException() {}, UncheckedTTransportException.class);
+        assertNoTExceptionInvocation(resultsSupplier, targets, statsFactory, classifiers, client, empty, new TProtocolException() {}, UncheckedTProtocolException.class);
     }
 
     private static void assertNormalInvocation(


### PR DESCRIPTION
This matches the JDK naming convention for UncheckedIOException.