### PR TITLE
Add ThriftEnumUnknownValue

### DIFF
--- a/drift-api/src/main/java/io/airlift/drift/annotations/ThriftEnumUnknownValue.java
+++ b/drift-api/src/main/java/io/airlift/drift/annotations/ThriftEnumUnknownValue.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2018 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.drift.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Marks the enum constant to use when decoding an unknown enum value.  If no enum constant is
+ * designated as the unknown value, and exception will be thrown during decoding.
+ */
+@Documented
+@Retention(RUNTIME)
+@Target(FIELD)
+public @interface ThriftEnumUnknownValue
+{
+}

--- a/drift-codec/README.md
+++ b/drift-codec/README.md
@@ -183,6 +183,11 @@ annotated with `@ThriftEnumValue` that supplies an int value.
 Drift does *not* support the potentially error-prone method of using
 the Java ordinal for automatic mapping.
 
+One enumeration constant may be annotated with `@ThriftEnumUnknownValue`,
+and this constant will be used when an unknown value is encountered during
+deserialization.  If no enum constant is designated as the unknown value,
+an exception will be thrown instead.
+
 ```java
 @ThriftEnum
 public enum Letter

--- a/drift-codec/src/main/java/io/airlift/drift/codec/internal/EnumThriftCodec.java
+++ b/drift-codec/src/main/java/io/airlift/drift/codec/internal/EnumThriftCodec.java
@@ -53,19 +53,9 @@ public class EnumThriftCodec<T extends Enum<T>>
             throws Exception
     {
         int enumValue = protocol.readI32();
-        if (enumValue >= 0) {
-            if (enumMetadata.hasExplicitThriftValue()) {
-                T enumConstant = enumMetadata.getByEnumValue().get(enumValue);
-                if (enumConstant != null) {
-                    return enumConstant;
-                }
-            }
-            else {
-                T[] enumConstants = enumMetadata.getEnumClass().getEnumConstants();
-                if (enumValue < enumConstants.length) {
-                    return enumConstants[enumValue];
-                }
-            }
+        T enumConstant = enumMetadata.getByEnumValue().get(enumValue);
+        if (enumConstant != null) {
+            return enumConstant;
         }
         // unknown, throw unknown value exception
         throw new UnknownEnumValueException(
@@ -80,14 +70,6 @@ public class EnumThriftCodec<T extends Enum<T>>
             throws Exception
     {
         requireNonNull(enumConstant, "enumConstant is null");
-
-        int enumValue;
-        if (enumMetadata.hasExplicitThriftValue()) {
-            enumValue = enumMetadata.getByEnumConstant().get(enumConstant);
-        }
-        else {
-            enumValue = enumConstant.ordinal();
-        }
-        protocol.writeI32(enumValue);
+        protocol.writeI32(enumMetadata.getByEnumConstant().get(enumConstant));
     }
 }

--- a/drift-codec/src/main/java/io/airlift/drift/codec/internal/EnumThriftCodec.java
+++ b/drift-codec/src/main/java/io/airlift/drift/codec/internal/EnumThriftCodec.java
@@ -23,6 +23,7 @@ import io.airlift.drift.protocol.TProtocolWriter;
 
 import javax.annotation.concurrent.Immutable;
 
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -57,12 +58,8 @@ public class EnumThriftCodec<T extends Enum<T>>
         if (enumConstant != null) {
             return enumConstant;
         }
-        // unknown, throw unknown value exception
-        throw new UnknownEnumValueException(
-                String.format(
-                        "Enum %s does not have a value for %s",
-                        enumMetadata.getEnumClass(),
-                        enumValue));
+        return enumMetadata.getUnknownEnumConstant()
+                .orElseThrow(() -> new UnknownEnumValueException(format("Enum %s does not have a constant for value: %s", enumMetadata.getEnumClass().getName(), enumValue)));
     }
 
     @Override

--- a/drift-codec/src/main/java/io/airlift/drift/codec/metadata/ThriftEnumMetadata.java
+++ b/drift-codec/src/main/java/io/airlift/drift/codec/metadata/ThriftEnumMetadata.java
@@ -122,11 +122,6 @@ public class ThriftEnumMetadata<T extends Enum<T>>
         return enumClass;
     }
 
-    public boolean hasExplicitThriftValue()
-    {
-        return byEnumValue != null;
-    }
-
     public Map<Integer, T> getByEnumValue()
     {
         return byEnumValue;

--- a/drift-codec/src/test/java/io/airlift/drift/codec/Letter.java
+++ b/drift-codec/src/test/java/io/airlift/drift/codec/Letter.java
@@ -16,12 +16,13 @@
 package io.airlift.drift.codec;
 
 import io.airlift.drift.annotations.ThriftEnum;
+import io.airlift.drift.annotations.ThriftEnumUnknownValue;
 import io.airlift.drift.annotations.ThriftEnumValue;
 
 @ThriftEnum
 public enum Letter
 {
-    A(65), B(66), C(67), D(68);
+    A(65), B(66), C(67), D(68), @ThriftEnumUnknownValue UNKNOWN(-1);
 
     private final int asciiValue;
 

--- a/drift-codec/src/test/java/io/airlift/drift/codec/metadata/TestThriftEnumMetadata.java
+++ b/drift-codec/src/test/java/io/airlift/drift/codec/metadata/TestThriftEnumMetadata.java
@@ -17,9 +17,12 @@ package io.airlift.drift.codec.metadata;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.drift.annotations.ThriftEnum;
+import io.airlift.drift.annotations.ThriftEnumUnknownValue;
 import io.airlift.drift.annotations.ThriftEnumValue;
 import io.airlift.drift.codec.Letter;
 import org.testng.annotations.Test;
+
+import java.util.Optional;
 
 import static io.airlift.drift.codec.metadata.ThriftEnumMetadataBuilder.thriftEnumMetadata;
 import static org.testng.Assert.assertEquals;
@@ -37,13 +40,16 @@ public class TestThriftEnumMetadata
                 .put(Letter.B, 66)
                 .put(Letter.C, 67)
                 .put(Letter.D, 68)
+                .put(Letter.UNKNOWN, -1)
                 .build());
         assertEquals(metadata.getByEnumValue(), ImmutableMap.<Integer, Letter>builder()
                 .put(65, Letter.A)
                 .put(66, Letter.B)
                 .put(67, Letter.C)
                 .put(68, Letter.D)
+                .put(-1, Letter.UNKNOWN)
                 .build());
+        assertEquals(metadata.getUnknownEnumConstant(), Optional.of(Letter.UNKNOWN));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Enum class .*MissingEnumAnnotation is not annotated with @ThriftEnum")
@@ -68,6 +74,12 @@ public class TestThriftEnumMetadata
     public void testDuplicateValues()
     {
         thriftEnumMetadata(DuplicateValues.class);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Enum class .*MultipleUnknownValues has multiple constants annotated with @ThriftEnumUnknownValue")
+    public void testMultipleUnknownValues()
+    {
+        thriftEnumMetadata(MultipleUnknownValues.class);
     }
 
     public enum MissingEnumAnnotation
@@ -114,6 +126,21 @@ public class TestThriftEnumMetadata
         public int value()
         {
             return 42;
+        }
+    }
+
+    @ThriftEnum
+    public enum MultipleUnknownValues
+    {
+        @ThriftEnumUnknownValue
+        FOO,
+        @ThriftEnumUnknownValue
+        BAR;
+
+        @ThriftEnumValue
+        public int value()
+        {
+            return this.ordinal();
         }
     }
 }


### PR DESCRIPTION
Marks the enum constant to use when decoding an unknown enum value.  If no
enum constant is designated as the unknown value, and exception will be
thrown during decoding.