### PR TITLE
Add constructor to DriftNettyMethodInvokerFactory

### DIFF
--- a/drift-transport-netty/src/main/java/io/airlift/drift/transport/netty/client/DriftNettyMethodInvokerFactory.java
+++ b/drift-transport-netty/src/main/java/io/airlift/drift/transport/netty/client/DriftNettyMethodInvokerFactory.java
@@ -62,6 +62,14 @@ public class DriftNettyMethodInvokerFactory<I>
 
     public DriftNettyMethodInvokerFactory(
             DriftNettyConnectionFactoryConfig factoryConfig,
+            Function<I, DriftNettyClientConfig> clientConfigurationProvider)
+    {
+        this(factoryConfig, clientConfigurationProvider, ByteBufAllocator.DEFAULT);
+    }
+
+    @VisibleForTesting
+    public DriftNettyMethodInvokerFactory(
+            DriftNettyConnectionFactoryConfig factoryConfig,
             Function<I, DriftNettyClientConfig> clientConfigurationProvider,
             ByteBufAllocator allocator)
     {


### PR DESCRIPTION
The ByteBufAllocator version was only intended for testing.