### PR TITLE
Add constructors for server transport classes

### DIFF
--- a/drift-transport-netty/src/main/java/io/airlift/drift/transport/netty/server/DriftNettyServerTransport.java
+++ b/drift-transport-netty/src/main/java/io/airlift/drift/transport/netty/server/DriftNettyServerTransport.java
@@ -15,6 +15,7 @@
  */
 package io.airlift.drift.transport.netty.server;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.airlift.drift.transport.netty.ssl.SslContextFactory;
 import io.airlift.drift.transport.server.ServerMethodInvoker;
 import io.airlift.drift.transport.server.ServerTransport;
@@ -53,6 +54,12 @@ public class DriftNettyServerTransport
 
     private final AtomicBoolean running = new AtomicBoolean();
 
+    public DriftNettyServerTransport(ServerMethodInvoker methodInvoker, DriftNettyServerConfig config)
+    {
+        this(methodInvoker, config, ByteBufAllocator.DEFAULT);
+    }
+
+    @VisibleForTesting
     public DriftNettyServerTransport(ServerMethodInvoker methodInvoker, DriftNettyServerConfig config, ByteBufAllocator allocator)
     {
         requireNonNull(methodInvoker, "methodInvoker is null");

--- a/drift-transport-netty/src/main/java/io/airlift/drift/transport/netty/server/DriftNettyServerTransportFactory.java
+++ b/drift-transport-netty/src/main/java/io/airlift/drift/transport/netty/server/DriftNettyServerTransportFactory.java
@@ -30,6 +30,11 @@ public class DriftNettyServerTransportFactory
     private final DriftNettyServerConfig config;
     private final ByteBufAllocator allocator;
 
+    public DriftNettyServerTransportFactory(DriftNettyServerConfig config)
+    {
+        this(config, ByteBufAllocator.DEFAULT);
+    }
+
     @Inject
     public DriftNettyServerTransportFactory(DriftNettyServerConfig config, ByteBufAllocator allocator)
     {


### PR DESCRIPTION
The ByteBufAllocator versions were not intended for public use.