### PR TITLE
Fix exception classifer for Thrift application exceptions

### DIFF
--- a/drift-client/src/main/java/io/airlift/drift/client/DriftInvocationHandler.java
+++ b/drift-client/src/main/java/io/airlift/drift/client/DriftInvocationHandler.java
@@ -167,7 +167,7 @@ class DriftInvocationHandler
         return result;
     }
 
-    private static Throwable unwrapUserException(Throwable t)
+    static Throwable unwrapUserException(Throwable t)
     {
         // unwrap deserialized user exception
         return (t instanceof DriftApplicationException) ? t.getCause() : t;

--- a/drift-client/src/main/java/io/airlift/drift/client/RetryPolicy.java
+++ b/drift-client/src/main/java/io/airlift/drift/client/RetryPolicy.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.drift.client.DriftInvocationHandler.unwrapUserException;
 import static io.airlift.drift.client.ExceptionClassification.HostStatus.DOWN;
 import static io.airlift.drift.client.ExceptionClassification.HostStatus.NORMAL;
 import static io.airlift.drift.client.ExceptionClassifier.NORMAL_RESULT;
@@ -113,7 +114,7 @@ public class RetryPolicy
         }
 
         // allow classifier to return a hard result
-        ExceptionClassification result = exceptionClassifier.classifyException(throwable);
+        ExceptionClassification result = exceptionClassifier.classifyException(unwrapUserException(throwable));
         if (result.isRetry().isPresent()) {
             return result;
         }

--- a/drift-client/src/test/java/io/airlift/drift/client/TestRetryPolicy.java
+++ b/drift-client/src/test/java/io/airlift/drift/client/TestRetryPolicy.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2018 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.drift.client;
+
+import io.airlift.drift.transport.client.DriftApplicationException;
+import io.airlift.drift.transport.client.DriftClientConfig;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.airlift.drift.client.ExceptionClassification.HostStatus.OVERLOADED;
+import static io.airlift.drift.client.ExceptionClassification.NORMAL_EXCEPTION;
+import static org.testng.Assert.assertSame;
+
+public class TestRetryPolicy
+{
+    @Test
+    public void testRetryUserException()
+    {
+        ExceptionClassification overloaded = new ExceptionClassification(Optional.of(true), OVERLOADED);
+        RetryPolicy policy = new RetryPolicy(new DriftClientConfig(), classifier -> {
+            if (classifier instanceof TestingUserException) {
+                return overloaded;
+            }
+            return NORMAL_EXCEPTION;
+        });
+        assertSame(policy.classifyException(new DriftApplicationException(new TestingUserException()), true), overloaded);
+        assertSame(policy.classifyException(new TestingUserException(), true), overloaded);
+    }
+
+    private static class TestingUserException
+            extends Exception
+    {}
+}

--- a/drift-integration-tests/pom.xml
+++ b/drift-integration-tests/pom.xml
@@ -132,5 +132,11 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/drift-integration-tests/src/test/java/io/airlift/drift/integration/guice/ExampleException.java
+++ b/drift-integration-tests/src/test/java/io/airlift/drift/integration/guice/ExampleException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2018 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.drift.integration.guice;
+
+import io.airlift.drift.annotations.ThriftConstructor;
+import io.airlift.drift.annotations.ThriftField;
+import io.airlift.drift.annotations.ThriftStruct;
+
+@ThriftStruct
+public class ExampleException
+        extends Exception
+{
+    private final boolean retryable;
+
+    @ThriftConstructor
+    public ExampleException(String message, boolean retryable)
+    {
+        super(message);
+        this.retryable = retryable;
+    }
+
+    @ThriftField(1)
+    @Override
+    public String getMessage()
+    {
+        return super.getMessage();
+    }
+
+    @ThriftField(2)
+    public boolean isRetryable()
+    {
+        return retryable;
+    }
+}

--- a/drift-integration-tests/src/test/java/io/airlift/drift/integration/guice/ThrowingService.java
+++ b/drift-integration-tests/src/test/java/io/airlift/drift/integration/guice/ThrowingService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2018 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.drift.integration.guice;
+
+import io.airlift.drift.annotations.ThriftMethod;
+import io.airlift.drift.annotations.ThriftService;
+
+@ThriftService("throwing")
+public interface ThrowingService
+{
+    @ThriftMethod
+    void fail(String message, boolean retryable)
+            throws ExampleException;
+}

--- a/drift-integration-tests/src/test/java/io/airlift/drift/integration/guice/ThrowingServiceHandler.java
+++ b/drift-integration-tests/src/test/java/io/airlift/drift/integration/guice/ThrowingServiceHandler.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2018 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.drift.integration.guice;
+
+public class ThrowingServiceHandler
+        implements ThrowingService
+{
+    @Override
+    public void fail(String message, boolean retryable)
+            throws ExampleException
+    {
+        throw new ExampleException(message, retryable);
+    }
+}


### PR DESCRIPTION
The exceptions were previously wrapped when passed to the classifier.