### PR TITLE
Use netty resource tracking in TestingPooledByteBufAllocator to print leak details.

### DIFF
--- a/drift-integration-tests/src/test/java/io/airlift/drift/integration/DriftNettyTesterUtil.java
+++ b/drift-integration-tests/src/test/java/io/airlift/drift/integration/DriftNettyTesterUtil.java
@@ -81,7 +81,7 @@ final class DriftNettyTesterUtil
                 .setTrustCertificate(ClientTestUtils.getCertificateChainFile())
                 .setSslEnabled(secure);
 
-        try (TestingPooledByteBufAllocator testingAllocator = new TestingPooledByteBufAllocator();
+        try (TestingPooledByteBufAllocator testingAllocator = TestingPooledByteBufAllocator.newAllocator();
                 DriftNettyMethodInvokerFactory<String> methodInvokerFactory = new DriftNettyMethodInvokerFactory<>(
                         new DriftNettyConnectionFactoryConfig().setConnectionPoolEnabled(true),
                         clientIdentity -> config,
@@ -119,7 +119,7 @@ final class DriftNettyTesterUtil
                 .setTrustCertificate(ClientTestUtils.getCertificateChainFile())
                 .setSslEnabled(secure);
 
-        try (TestingPooledByteBufAllocator testingAllocator = new TestingPooledByteBufAllocator();
+        try (TestingPooledByteBufAllocator testingAllocator = TestingPooledByteBufAllocator.newAllocator();
                 DriftNettyMethodInvokerFactory<?> methodInvokerFactory = createStaticDriftNettyMethodInvokerFactory(config, testingAllocator)) {
             DriftClientFactory proxyFactory = new DriftClientFactory(CODEC_MANAGER, methodInvokerFactory, addressSelector);
 
@@ -153,7 +153,7 @@ final class DriftNettyTesterUtil
                 .setTrustCertificate(ClientTestUtils.getCertificateChainFile())
                 .setSslEnabled(secure);
 
-        try (TestingPooledByteBufAllocator testingAllocator = new TestingPooledByteBufAllocator();
+        try (TestingPooledByteBufAllocator testingAllocator = TestingPooledByteBufAllocator.newAllocator();
                 DriftNettyMethodInvokerFactory<String> methodInvokerFactory = new DriftNettyMethodInvokerFactory<>(
                         new DriftNettyConnectionFactoryConfig().setConnectionPoolEnabled(true),
                         clientIdentity -> config,
@@ -184,7 +184,7 @@ final class DriftNettyTesterUtil
             return 0;
         }
 
-        try (TestingPooledByteBufAllocator testingAllocator = new TestingPooledByteBufAllocator()) {
+        try (TestingPooledByteBufAllocator testingAllocator = TestingPooledByteBufAllocator.newAllocator()) {
             return logDriftClientBinder(address, headerValue, entries, new DriftNettyClientModule(testingAllocator), filters, transport, protocol, secure);
         }
     }

--- a/drift-integration-tests/src/test/java/io/airlift/drift/integration/TestClientsWithDriftNettyServer.java
+++ b/drift-integration-tests/src/test/java/io/airlift/drift/integration/TestClientsWithDriftNettyServer.java
@@ -107,7 +107,7 @@ public class TestClientsWithDriftNettyServer
                 .setSslEnabled(true)
                 .setTrustCertificate(ClientTestUtils.getCertificateChainFile())
                 .setKey(ClientTestUtils.getPrivateKeyFile());
-        TestingPooledByteBufAllocator testingAllocator = new TestingPooledByteBufAllocator();
+        TestingPooledByteBufAllocator testingAllocator = TestingPooledByteBufAllocator.newAllocator();
         DriftServer driftServer = new DriftServer(
                 new DriftNettyServerTransportFactory(config, testingAllocator),
                 CODEC_MANAGER,

--- a/drift-integration-tests/src/test/java/io/airlift/drift/integration/TestClientsWithDriftNettyServerTransport.java
+++ b/drift-integration-tests/src/test/java/io/airlift/drift/integration/TestClientsWithDriftNettyServerTransport.java
@@ -105,7 +105,7 @@ public class TestClientsWithDriftNettyServerTransport
                 .setSslEnabled(true)
                 .setTrustCertificate(ClientTestUtils.getCertificateChainFile())
                 .setKey(ClientTestUtils.getPrivateKeyFile());
-        TestingPooledByteBufAllocator testingAllocator = new TestingPooledByteBufAllocator();
+        TestingPooledByteBufAllocator testingAllocator = TestingPooledByteBufAllocator.newAllocator();
         ServerTransport serverTransport = new DriftNettyServerTransportFactory(config, testingAllocator).createServerTransport(methodInvoker);
         try {
             serverTransport.start();

--- a/drift-integration-tests/src/test/java/io/airlift/drift/integration/guice/TestGuiceIntegration.java
+++ b/drift-integration-tests/src/test/java/io/airlift/drift/integration/guice/TestGuiceIntegration.java
@@ -70,7 +70,7 @@ public class TestGuiceIntegration
     {
         int port = findUnusedPort();
 
-        TestingPooledByteBufAllocator testingAllocator = new TestingPooledByteBufAllocator();
+        TestingPooledByteBufAllocator testingAllocator = TestingPooledByteBufAllocator.newAllocator();
         Bootstrap bootstrap = new Bootstrap(
                 new DriftNettyServerModule(testingAllocator),
                 new DriftNettyClientModule(testingAllocator),

--- a/drift-transport-netty/pom.xml
+++ b/drift-transport-netty/pom.xml
@@ -103,6 +103,12 @@
             <artifactId>javax.annotation-api</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>io.airlift</groupId>

--- a/drift-transport-netty/src/test/java/io/airlift/drift/transport/netty/client/TestDriftNettyMethodInvoker.java
+++ b/drift-transport-netty/src/test/java/io/airlift/drift/transport/netty/client/TestDriftNettyMethodInvoker.java
@@ -205,7 +205,7 @@ public class TestDriftNettyMethodInvoker
 
     private static int testMethodInvoker(ServerMethodInvoker methodInvoker, List<ToIntFunction<HostAndPort>> clients)
     {
-        TestingPooledByteBufAllocator testingAllocator = new TestingPooledByteBufAllocator();
+        TestingPooledByteBufAllocator testingAllocator = TestingPooledByteBufAllocator.newAllocator();
         ServerTransport serverTransport = new DriftNettyServerTransportFactory(new DriftNettyServerConfig(), testingAllocator).createServerTransport(methodInvoker);
         try {
             serverTransport.start();
@@ -297,7 +297,7 @@ public class TestDriftNettyMethodInvoker
                 .setTransport(transport)
                 .setProtocol(protocol);
 
-        try (TestingPooledByteBufAllocator testingAllocator = new TestingPooledByteBufAllocator();
+        try (TestingPooledByteBufAllocator testingAllocator = TestingPooledByteBufAllocator.newAllocator();
                 DriftNettyMethodInvokerFactory<Void> methodInvokerFactory = new DriftNettyMethodInvokerFactory<>(
                         new DriftNettyConnectionFactoryConfig().setConnectionPoolEnabled(true),
                         clientIdentity -> config,
@@ -372,7 +372,7 @@ public class TestDriftNettyMethodInvoker
     private static int logNiftyInvocationHandlerOptional(HostAndPort address, List<DriftLogEntry> entries)
     {
         DriftNettyClientConfig config = new DriftNettyClientConfig();
-        try (TestingPooledByteBufAllocator testingAllocator = new TestingPooledByteBufAllocator();
+        try (TestingPooledByteBufAllocator testingAllocator = TestingPooledByteBufAllocator.newAllocator();
                 DriftNettyMethodInvokerFactory<Void> methodInvokerFactory = new DriftNettyMethodInvokerFactory<>(
                         new DriftNettyConnectionFactoryConfig().setConnectionPoolEnabled(true),
                         clientIdentity -> config,

--- a/drift-transport-netty/src/test/java/io/airlift/drift/transport/netty/server/TestDriftNettyServerTransport.java
+++ b/drift-transport-netty/src/test/java/io/airlift/drift/transport/netty/server/TestDriftNettyServerTransport.java
@@ -222,7 +222,7 @@ public class TestDriftNettyServerTransport
     {
         DriftNettyServerConfig config = new DriftNettyServerConfig()
                 .setAssumeClientsSupportOutOfOrderResponses(assumeClientsSupportOutOfOrderResponses);
-        TestingPooledByteBufAllocator testingAllocator = new TestingPooledByteBufAllocator();
+        TestingPooledByteBufAllocator testingAllocator = TestingPooledByteBufAllocator.newAllocator();
         ServerTransport serverTransport = new DriftNettyServerTransportFactory(config, testingAllocator).createServerTransport(methodInvoker);
         try {
             serverTransport.start();


### PR DESCRIPTION
Use netty resource tracking in TestingPooledByteBufAllocator to print leak details.

Test plan:
- commented out a ByteBuf.release() call in SimpleFrameCodec.java
- ran `mvn test`
- as expected, the test failed with an AssertionError("FAIL")
- as expected, details about the leaked buffer were printed before the failure
- all tests pass when the release() call is restored