### PR TITLE
Allow configuring retry on a per method basis

### DIFF
--- a/drift-api/src/main/java/io/airlift/drift/annotations/ThriftRetryable.java
+++ b/drift-api/src/main/java/io/airlift/drift/annotations/ThriftRetryable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2020 The Drift Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,24 +17,18 @@ package io.airlift.drift.annotations;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
+import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Provides mapping for Thrift method exceptions
+ * Indicates if an exception thrown by a method is retryable.
  */
 @Documented
 @Retention(RUNTIME)
-public @interface ThriftException
+@Target(TYPE_USE)
+public @interface ThriftRetryable
 {
-    Class<? extends Throwable> type();
-
-    short id();
-
-    Retryable retryable() default Retryable.UNKNOWN;
-
-    enum Retryable
-    {
-        UNKNOWN, FALSE, TRUE
-    }
+    boolean value();
 }

--- a/drift-client/src/test/java/io/airlift/drift/client/TestDriftMethodInvocation.java
+++ b/drift-client/src/test/java/io/airlift/drift/client/TestDriftMethodInvocation.java
@@ -75,6 +75,7 @@ public class TestDriftMethodInvocation
             ImmutableList.of(),
             (ThriftCodec<Object>) (Object) new ShortThriftCodec(),
             ImmutableMap.of(),
+            ImmutableMap.of(),
             false,
             true);
     private static final Error UNEXPECTED_EXCEPTION = new Error("unexpected exception");
@@ -795,7 +796,7 @@ public class TestDriftMethodInvocation
         {
             Exception exception = new ClassifiedException(new ExceptionClassification(Optional.of(retry), hostStatus));
             if (wrapWithApplicationException) {
-                exception = new DriftApplicationException(exception);
+                exception = new DriftApplicationException(exception, Optional.empty());
             }
             return exception;
         }

--- a/drift-idl-generator/src/main/java/io/airlift/drift/idl/generator/ThriftIdlGenerator.java
+++ b/drift-idl-generator/src/main/java/io/airlift/drift/idl/generator/ThriftIdlGenerator.java
@@ -30,6 +30,7 @@ import io.airlift.drift.codec.metadata.MetadataWarningException;
 import io.airlift.drift.codec.metadata.ThriftCatalog;
 import io.airlift.drift.codec.metadata.ThriftFieldMetadata;
 import io.airlift.drift.codec.metadata.ThriftMethodMetadata;
+import io.airlift.drift.codec.metadata.ThriftMethodMetadata.ExceptionInfo;
 import io.airlift.drift.codec.metadata.ThriftServiceMetadata;
 import io.airlift.drift.codec.metadata.ThriftStructMetadata;
 import io.airlift.drift.codec.metadata.ThriftType;
@@ -284,7 +285,8 @@ public class ThriftIdlGenerator
                 }
             }
 
-            for (ThriftType exception : method.getValue().getExceptions().values()) {
+            for (ExceptionInfo exceptionInfo : method.getValue().getExceptions().values()) {
+                ThriftType exception = exceptionInfo.getThriftType();
                 if (!verifyField(exception)) {
                     ok = false;
                     if (!quiet) {

--- a/drift-idl-generator/src/main/java/io/airlift/drift/idl/generator/ThriftIdlRenderer.java
+++ b/drift-idl-generator/src/main/java/io/airlift/drift/idl/generator/ThriftIdlRenderer.java
@@ -237,7 +237,7 @@ public final class ThriftIdlRenderer
             List<String> exceptions = mapWithIndex(method.getExceptions().entrySet().stream(),
                     (entry, index) -> format("%s: %s ex%s",
                             entry.getKey(),
-                            typeName(entry.getValue()),
+                            typeName(entry.getValue().getThriftType()),
                             index + 1))
                     .collect(toList());
             builder.append("\n")

--- a/drift-idl-generator/src/test/java/io/airlift/drift/idl/generator/DriftScribe.java
+++ b/drift-idl-generator/src/test/java/io/airlift/drift/idl/generator/DriftScribe.java
@@ -19,6 +19,7 @@ import io.airlift.drift.annotations.ThriftDocumentation;
 import io.airlift.drift.annotations.ThriftId;
 import io.airlift.drift.annotations.ThriftMethod;
 import io.airlift.drift.annotations.ThriftOrder;
+import io.airlift.drift.annotations.ThriftRetryable;
 import io.airlift.drift.annotations.ThriftService;
 
 import java.util.List;
@@ -50,9 +51,9 @@ public interface DriftScribe
     @ThriftMethod
     DriftResultCode logFormattedMessage(String format, Map<String, DriftLogEntry> messages, int maxSize)
             throws
-            @ThriftId(1) ScribeDataException,
-            @ThriftId(2) ScribeTransportException,
-            @ThriftId(3) ScribeMessageException;
+            @ThriftId(1) @ThriftRetryable(false) ScribeDataException,
+            @ThriftId(2) @ThriftRetryable(true) ScribeTransportException,
+            @ThriftId(3) @ThriftRetryable(false) ScribeMessageException;
 
     @ThriftDocumentation("Check if service is up")
     @ThriftOrder(3)

--- a/drift-integration-tests/src/test/java/io/airlift/drift/integration/TestClientsWithDriftNettyServerTransport.java
+++ b/drift-integration-tests/src/test/java/io/airlift/drift/integration/TestClientsWithDriftNettyServerTransport.java
@@ -133,6 +133,7 @@ public class TestClientsWithDriftNettyServerTransport
                     (ThriftCodec<Object>) CODEC_MANAGER.getCodec(list(CODEC_MANAGER.getCodec(DriftLogEntry.class).getType())))),
             (ThriftCodec<Object>) (Object) CODEC_MANAGER.getCodec(DriftResultCode.class),
             ImmutableMap.of(),
+            ImmutableMap.of(),
             false,
             true);
 

--- a/drift-integration-tests/src/test/java/io/airlift/drift/integration/guice/NonRetryableException.java
+++ b/drift-integration-tests/src/test/java/io/airlift/drift/integration/guice/NonRetryableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2020 The Drift Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,28 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.airlift.drift.annotations;
+package io.airlift.drift.integration.guice;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.Retention;
+import io.airlift.drift.annotations.ThriftConstructor;
+import io.airlift.drift.annotations.ThriftField;
+import io.airlift.drift.annotations.ThriftStruct;
 
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
-/**
- * Provides mapping for Thrift method exceptions
- */
-@Documented
-@Retention(RUNTIME)
-public @interface ThriftException
+@ThriftStruct
+public class NonRetryableException
+        extends Exception
 {
-    Class<? extends Throwable> type();
-
-    short id();
-
-    Retryable retryable() default Retryable.UNKNOWN;
-
-    enum Retryable
+    @ThriftConstructor
+    public NonRetryableException(String message)
     {
-        UNKNOWN, FALSE, TRUE
+        super(message);
+    }
+
+    @ThriftField(1)
+    @Override
+    public String getMessage()
+    {
+        return super.getMessage();
     }
 }

--- a/drift-integration-tests/src/test/java/io/airlift/drift/integration/guice/RetryableException.java
+++ b/drift-integration-tests/src/test/java/io/airlift/drift/integration/guice/RetryableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Facebook, Inc.
+ * Copyright (C) 2020 The Drift Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,28 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.airlift.drift.annotations;
+package io.airlift.drift.integration.guice;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.Retention;
+import io.airlift.drift.annotations.ThriftConstructor;
+import io.airlift.drift.annotations.ThriftField;
+import io.airlift.drift.annotations.ThriftStruct;
 
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
-/**
- * Provides mapping for Thrift method exceptions
- */
-@Documented
-@Retention(RUNTIME)
-public @interface ThriftException
+@ThriftStruct
+public class RetryableException
+        extends Exception
 {
-    Class<? extends Throwable> type();
-
-    short id();
-
-    Retryable retryable() default Retryable.UNKNOWN;
-
-    enum Retryable
+    @ThriftConstructor
+    public RetryableException(String message)
     {
-        UNKNOWN, FALSE, TRUE
+        super(message);
+    }
+
+    @ThriftField(1)
+    @Override
+    public String getMessage()
+    {
+        return super.getMessage();
     }
 }

--- a/drift-integration-tests/src/test/java/io/airlift/drift/integration/guice/ThrowingService.java
+++ b/drift-integration-tests/src/test/java/io/airlift/drift/integration/guice/ThrowingService.java
@@ -17,7 +17,9 @@ package io.airlift.drift.integration.guice;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.drift.TException;
+import io.airlift.drift.annotations.ThriftId;
 import io.airlift.drift.annotations.ThriftMethod;
+import io.airlift.drift.annotations.ThriftRetryable;
 import io.airlift.drift.annotations.ThriftService;
 import io.airlift.units.DataSize;
 
@@ -27,6 +29,12 @@ import static io.airlift.units.DataSize.Unit.KILOBYTE;
 public interface ThrowingService
 {
     DataSize MAX_FRAME_SIZE = new DataSize(10, KILOBYTE);
+
+    @ThriftMethod
+    void failWithException(boolean retryable)
+            throws
+            @ThriftId(1) @ThriftRetryable(true) RetryableException,
+            @ThriftId(2) @ThriftRetryable(false) NonRetryableException;
 
     @ThriftMethod
     void fail(String message, boolean retryable)

--- a/drift-integration-tests/src/test/java/io/airlift/drift/integration/guice/ThrowingServiceHandler.java
+++ b/drift-integration-tests/src/test/java/io/airlift/drift/integration/guice/ThrowingServiceHandler.java
@@ -39,6 +39,16 @@ public class ThrowingServiceHandler
     }
 
     @Override
+    public void failWithException(boolean retryable)
+            throws RetryableException, NonRetryableException
+    {
+        if (retryable) {
+            throw new RetryableException("RETRY");
+        }
+        throw new NonRetryableException("NO RETRY");
+    }
+
+    @Override
     public byte[] generateTooLargeFrame()
     {
         return new byte[toIntExact(MAX_FRAME_SIZE.toBytes()) + 1];

--- a/drift-transport-apache/src/main/java/io/airlift/drift/transport/apache/client/ApacheThriftMethodInvoker.java
+++ b/drift-transport-apache/src/main/java/io/airlift/drift/transport/apache/client/ApacheThriftMethodInvoker.java
@@ -247,13 +247,16 @@ public class ApacheThriftMethodInvoker
 
         Object results = null;
         Exception exception = null;
+        short exceptionId = 0;
+
         try {
             while (reader.nextField()) {
-                if (reader.getFieldId() == 0) {
+                exceptionId = reader.getFieldId();
+                if (exceptionId == 0) {
                     results = reader.readField(method.getResultCodec());
                 }
                 else {
-                    ThriftCodec<Object> exceptionCodec = method.getExceptionCodecs().get(reader.getFieldId());
+                    ThriftCodec<Object> exceptionCodec = method.getExceptionCodecs().get(exceptionId);
                     if (exceptionCodec != null) {
                         exception = (Exception) reader.readField(exceptionCodec);
                     }
@@ -273,7 +276,7 @@ public class ApacheThriftMethodInvoker
         }
 
         if (exception != null) {
-            throw new DriftApplicationException(exception);
+            throw new DriftApplicationException(exception, method.isExceptionRetryable(exceptionId));
         }
 
         if (method.getResultCodec().getType() == ThriftType.VOID) {

--- a/drift-transport-apache/src/test/java/io/airlift/drift/transport/apache/TestApacheThriftMethodInvoker.java
+++ b/drift-transport-apache/src/test/java/io/airlift/drift/transport/apache/TestApacheThriftMethodInvoker.java
@@ -209,6 +209,7 @@ public class TestApacheThriftMethodInvoker
                     ImmutableList.of(parameter),
                     (ThriftCodec<Object>) (Object) codecManager.getCodec(DriftResultCode.class),
                     ImmutableMap.of(),
+                    ImmutableMap.of(),
                     false,
                     true);
 
@@ -239,6 +240,7 @@ public class TestApacheThriftMethodInvoker
                     "Log",
                     ImmutableList.of(parameter),
                     (ThriftCodec<Object>) (Object) codecManager.getCodec(DriftResultCode.class),
+                    ImmutableMap.of(),
                     ImmutableMap.of(),
                     false,
                     true);

--- a/drift-transport-netty/src/main/java/io/airlift/drift/transport/netty/client/ThriftClientHandler.java
+++ b/drift-transport-netty/src/main/java/io/airlift/drift/transport/netty/client/ThriftClientHandler.java
@@ -449,12 +449,15 @@ public class ThriftClientHandler
 
                 Object results = null;
                 Exception exception = null;
+                short exceptionId = 0;
+
                 while (reader.nextField()) {
-                    if (reader.getFieldId() == 0) {
+                    exceptionId = reader.getFieldId();
+                    if (exceptionId == 0) {
                         results = reader.readField(method.getResultCodec());
                     }
                     else {
-                        ThriftCodec<Object> exceptionCodec = method.getExceptionCodecs().get(reader.getFieldId());
+                        ThriftCodec<Object> exceptionCodec = method.getExceptionCodecs().get(exceptionId);
                         if (exceptionCodec != null) {
                             exception = (Exception) reader.readField(exceptionCodec);
                         }
@@ -463,11 +466,12 @@ public class ThriftClientHandler
                         }
                     }
                 }
+
                 reader.readStructEnd();
                 protocolReader.readMessageEnd();
 
                 if (exception != null) {
-                    throw new DriftApplicationException(exception);
+                    throw new DriftApplicationException(exception, method.isExceptionRetryable(exceptionId));
                 }
 
                 if (method.getResultCodec().getType() == ThriftType.VOID) {

--- a/drift-transport-netty/src/test/java/io/airlift/drift/transport/netty/client/TestDriftNettyMethodInvoker.java
+++ b/drift-transport-netty/src/test/java/io/airlift/drift/transport/netty/client/TestDriftNettyMethodInvoker.java
@@ -108,6 +108,7 @@ public class TestDriftNettyMethodInvoker
                     (ThriftCodec<Object>) CODEC_MANAGER.getCodec(list(CODEC_MANAGER.getCodec(DriftLogEntry.class).getType())))),
             (ThriftCodec<Object>) (Object) CODEC_MANAGER.getCodec(DriftResultCode.class),
             ImmutableMap.of(),
+            ImmutableMap.of(),
             false,
             true);
 
@@ -349,6 +350,7 @@ public class TestDriftNettyMethodInvoker
                         ImmutableList.of(),
                         (ThriftCodec<Object>) (Object) new VoidThriftCodec(),
                         ImmutableMap.of(),
+                        ImmutableMap.of(),
                         false,
                         true),
                 () -> HostAndPort.fromParts("localhost", 1234),
@@ -388,6 +390,7 @@ public class TestDriftNettyMethodInvoker
                     "Log",
                     ImmutableList.of(parameter),
                     (ThriftCodec<Object>) (Object) CODEC_MANAGER.getCodec(DriftResultCode.class),
+                    ImmutableMap.of(),
                     ImmutableMap.of(),
                     false,
                     true);

--- a/drift-transport-netty/src/test/java/io/airlift/drift/transport/netty/server/TestDriftNettyServerTransport.java
+++ b/drift-transport-netty/src/test/java/io/airlift/drift/transport/netty/server/TestDriftNettyServerTransport.java
@@ -83,6 +83,7 @@ public class TestDriftNettyServerTransport
                     (ThriftCodec<Object>) CODEC_MANAGER.getCodec(list(CODEC_MANAGER.getCodec(DriftLogEntry.class).getType())))),
             (ThriftCodec<Object>) (Object) CODEC_MANAGER.getCodec(DriftResultCode.class),
             ImmutableMap.of(),
+            ImmutableMap.of(),
             false,
             true);
 

--- a/drift-transport-spi/src/main/java/io/airlift/drift/transport/client/DriftApplicationException.java
+++ b/drift-transport-spi/src/main/java/io/airlift/drift/transport/client/DriftApplicationException.java
@@ -17,13 +17,23 @@ package io.airlift.drift.transport.client;
 
 import io.airlift.drift.TException;
 
+import java.util.Optional;
+
 import static java.util.Objects.requireNonNull;
 
 public final class DriftApplicationException
         extends TException
 {
-    public DriftApplicationException(Throwable applicationException)
+    private final Optional<Boolean> retryable;
+
+    public DriftApplicationException(Throwable applicationException, Optional<Boolean> retryable)
     {
         super(requireNonNull(applicationException, "applicationException is null"));
+        this.retryable = requireNonNull(retryable, "retryable is null");
+    }
+
+    public Optional<Boolean> isRetryable()
+    {
+        return retryable;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>94</version>
+        <version>97</version>
     </parent>
 
     <groupId>io.airlift.drift</groupId>
@@ -51,7 +51,7 @@
         <air.check.skip-pmd>true</air.check.skip-pmd>
         <air.check.skip-jacoco>true</air.check.skip-jacoco>
 
-        <dep.airlift.version>0.188</dep.airlift.version>
+        <dep.airlift.version>0.193</dep.airlift.version>
         <dep.takari-plugin.version>2.9.1</dep.takari-plugin.version>
         <dep.maven.version>3.5.3</dep.maven.version>
     </properties>


### PR DESCRIPTION
The classifier is used in preference to the per method retry value, effectively making it a default, as the classifier can take advantage of information in the actual exception instance to make a decision.