### PR TITLE
Add option to skip the maven plugin execution

### DIFF
--- a/drift-maven-plugin/src/main/java/io/airlift/drift/maven/IdlGeneratorMojo.java
+++ b/drift-maven-plugin/src/main/java/io/airlift/drift/maven/IdlGeneratorMojo.java
@@ -100,10 +100,18 @@ public class IdlGeneratorMojo
     @Parameter
     private boolean quiet;
 
+    @Parameter(property = "drift.skip", defaultValue = "false")
+    private boolean skip;
+
     @Override
     public void execute()
             throws MojoExecutionException
     {
+        if (skip) {
+            getLog().info("Drift IDL generation is skipped.");
+            return;
+        }
+
         ClassLoader classLoader = createClassLoaderFromCompileTimeDependencies();
 
         ThriftIdlGeneratorConfig config = ThriftIdlGeneratorConfig.builder()


### PR DESCRIPTION
We need to skip the plugin execution for some profiles due the fact that each execution regenerates the .thrift file no matter if the classes were changed or not. 