### PR TITLE
Restore pre-4.2.0 pooled allocator

### DIFF
--- a/drift-transport-netty/src/main/java/io/airlift/drift/transport/netty/client/DriftNettyClientModule.java
+++ b/drift-transport-netty/src/main/java/io/airlift/drift/transport/netty/client/DriftNettyClientModule.java
@@ -27,6 +27,7 @@ import com.google.inject.TypeLiteral;
 import io.airlift.drift.transport.client.DriftClientConfig;
 import io.airlift.drift.transport.client.MethodInvokerFactory;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.PooledByteBufAllocator;
 import jakarta.annotation.PreDestroy;
 
 import java.lang.annotation.Annotation;
@@ -42,7 +43,7 @@ public class DriftNettyClientModule
 
     public DriftNettyClientModule()
     {
-        this(ByteBufAllocator.DEFAULT);
+        this(PooledByteBufAllocator.DEFAULT);
     }
 
     @VisibleForTesting

--- a/drift-transport-netty/src/main/java/io/airlift/drift/transport/netty/server/DriftNettyServerTransportFactory.java
+++ b/drift-transport-netty/src/main/java/io/airlift/drift/transport/netty/server/DriftNettyServerTransportFactory.java
@@ -20,6 +20,7 @@ import io.airlift.drift.transport.server.ServerMethodInvoker;
 import io.airlift.drift.transport.server.ServerTransport;
 import io.airlift.drift.transport.server.ServerTransportFactory;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.PooledByteBufAllocator;
 
 import static java.util.Objects.requireNonNull;
 
@@ -31,7 +32,7 @@ public class DriftNettyServerTransportFactory
 
     public DriftNettyServerTransportFactory(DriftNettyServerConfig config)
     {
-        this(config, ByteBufAllocator.DEFAULT);
+        this(config, PooledByteBufAllocator.DEFAULT);
     }
 
     @Inject


### PR DESCRIPTION
New AdaptivePooledAllocator seems to break drift in unexpected ways. Restoring to previous default allocator works fine.