### PR TITLE
ignore synthetic method when try to find ThriftEnumValue method

### DIFF
--- a/drift-codec/src/main/java/io/airlift/drift/codec/metadata/ThriftEnumMetadata.java
+++ b/drift-codec/src/main/java/io/airlift/drift/codec/metadata/ThriftEnumMetadata.java
@@ -55,6 +55,9 @@ public class ThriftEnumMetadata<T extends Enum<T>>
 
         Method enumValueMethod = null;
         for (Method method : enumClass.getMethods()) {
+            if (method.isSynthetic()) {
+                continue;
+            }
             if (method.isAnnotationPresent(ThriftEnumValue.class)) {
                 checkArgument(
                         Modifier.isPublic(method.getModifiers()),

--- a/drift-codec/src/test/java/io/airlift/drift/codec/GenericReturnValue.java
+++ b/drift-codec/src/test/java/io/airlift/drift/codec/GenericReturnValue.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.drift.codec;
+
+public interface GenericReturnValue<T>
+{
+    @SuppressWarnings("unused")  // used to test bridge method
+    T getEnumValue();
+}

--- a/drift-codec/src/test/java/io/airlift/drift/codec/GenericReturnValueEnum.java
+++ b/drift-codec/src/test/java/io/airlift/drift/codec/GenericReturnValueEnum.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.drift.codec;
+
+import io.airlift.drift.annotations.ThriftEnum;
+import io.airlift.drift.annotations.ThriftEnumValue;
+
+@ThriftEnum
+public enum GenericReturnValueEnum implements GenericReturnValue<Integer> {
+    GENERIC_RETURN_VALUE_ENUMValueEnum(1);
+
+    private final Integer enumValue;
+
+    GenericReturnValueEnum(Integer enumValue)
+    {
+        this.enumValue = enumValue;
+    }
+
+    @ThriftEnumValue
+    @Override
+    public Integer getEnumValue()
+    {
+        return enumValue;
+    }
+}

--- a/drift-codec/src/test/java/io/airlift/drift/codec/GenericReturnValueEnum.java
+++ b/drift-codec/src/test/java/io/airlift/drift/codec/GenericReturnValueEnum.java
@@ -19,8 +19,10 @@ import io.airlift.drift.annotations.ThriftEnum;
 import io.airlift.drift.annotations.ThriftEnumValue;
 
 @ThriftEnum
-public enum GenericReturnValueEnum implements GenericReturnValue<Integer> {
-    GENERIC_RETURN_VALUE_ENUMValueEnum(1);
+public enum GenericReturnValueEnum
+        implements GenericReturnValue<Integer>
+{
+    GENERIC_RETURN_VALUE_ENUM(1);
 
     private final Integer enumValue;
 

--- a/drift-codec/src/test/java/io/airlift/drift/codec/TestThriftCodecManager.java
+++ b/drift-codec/src/test/java/io/airlift/drift/codec/TestThriftCodecManager.java
@@ -194,6 +194,14 @@ public class TestThriftCodecManager
         testRoundTripSerialize(union);
     }
 
+    @Test
+    private void testGenericReturnValueEnum() throws Exception
+    {
+        ThriftEnumMetadata<GenericReturnValueEnum> enumMetadata = thriftEnumMetadata(GenericReturnValueEnum.class);
+        testRoundTripSerialize(enumType(enumMetadata), GenericReturnValueEnum.GENERIC_RETURN_VALUE_ENUMValueEnum);
+        testRoundTripSerialize(list(enumType(enumMetadata)), ImmutableList.copyOf(GenericReturnValueEnum.values()));
+    }
+
     private <T> void testRoundTripSerialize(T value)
             throws Exception
     {

--- a/drift-codec/src/test/java/io/airlift/drift/codec/TestThriftCodecManager.java
+++ b/drift-codec/src/test/java/io/airlift/drift/codec/TestThriftCodecManager.java
@@ -195,10 +195,11 @@ public class TestThriftCodecManager
     }
 
     @Test
-    private void testGenericReturnValueEnum() throws Exception
+    public void testGenericReturnValueEnum()
+            throws Exception
     {
         ThriftEnumMetadata<GenericReturnValueEnum> enumMetadata = thriftEnumMetadata(GenericReturnValueEnum.class);
-        testRoundTripSerialize(enumType(enumMetadata), GenericReturnValueEnum.GENERIC_RETURN_VALUE_ENUMValueEnum);
+        testRoundTripSerialize(enumType(enumMetadata), GenericReturnValueEnum.GENERIC_RETURN_VALUE_ENUM);
         testRoundTripSerialize(list(enumType(enumMetadata)), ImmutableList.copyOf(GenericReturnValueEnum.values()));
     }
 


### PR DESCRIPTION
if an enum implements a generic interface ,and the interface has a method that return the generic type,and that method is annotated with @ThriftEnumValue,then an exception will be thrown.That is because the bridge method is also annotated with @ThriftEnumValue but the bridge method's return type is Object


