### PR TITLE
Prevent test hangs from loopback port conflicts

### DIFF
--- a/drift-integration-tests/src/test/java/io/airlift/drift/integration/TestClientsWithApacheServer.java
+++ b/drift-integration-tests/src/test/java/io/airlift/drift/integration/TestClientsWithApacheServer.java
@@ -38,6 +38,7 @@ import org.testng.annotations.Test;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLServerSocket;
 
+import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.function.ToIntFunction;
 
@@ -49,6 +50,7 @@ import static io.airlift.drift.integration.DriftNettyTesterUtil.driftNettyTestCl
 import static io.airlift.drift.integration.LegacyApacheThriftTesterUtil.legacyApacheThriftTestClients;
 import static io.airlift.drift.transport.netty.codec.Protocol.FB_COMPACT;
 import static io.airlift.drift.transport.netty.codec.Transport.HEADER;
+import static java.net.InetAddress.getLoopbackAddress;
 import static java.util.Collections.nCopies;
 import static org.testng.Assert.assertEquals;
 
@@ -140,8 +142,9 @@ public class TestClientsWithApacheServer
             try {
                 serverThread.start();
 
-                int localPort = serverSocket.getServerSocket().getLocalPort();
-                HostAndPort address = HostAndPort.fromParts("localhost", localPort);
+                String host = serverSocket.getServerSocket().getInetAddress().getHostAddress();
+                int port = serverSocket.getServerSocket().getLocalPort();
+                HostAndPort address = HostAndPort.fromParts(host, port);
 
                 int sum = 0;
                 for (ToIntFunction<HostAndPort> client : clients) {
@@ -160,12 +163,13 @@ public class TestClientsWithApacheServer
             throws TTransportException
     {
         if (!secure) {
-            return new TServerSocket(0);
+            return new TServerSocket(new InetSocketAddress(getLoopbackAddress(), 0));
         }
 
         try {
             SSLContext serverSslContext = ClientTestUtils.getServerSslContext();
-            SSLServerSocket serverSocket = (SSLServerSocket) serverSslContext.getServerSocketFactory().createServerSocket(0);
+            SSLServerSocket serverSocket = (SSLServerSocket) serverSslContext.getServerSocketFactory().createServerSocket();
+            serverSocket.bind(new InetSocketAddress(getLoopbackAddress(), 0));
             return new TServerSocket(serverSocket);
         }
         catch (Exception e) {

--- a/drift-transport-apache/src/test/java/io/airlift/drift/transport/apache/TestApacheThriftMethodInvoker.java
+++ b/drift-transport-apache/src/test/java/io/airlift/drift/transport/apache/TestApacheThriftMethodInvoker.java
@@ -54,6 +54,7 @@ import org.apache.thrift.transport.TTransportFactory;
 import org.apache.thrift.transport.layered.TFramedTransport;
 import org.testng.annotations.Test;
 
+import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.ToIntFunction;
@@ -61,6 +62,7 @@ import java.util.function.ToIntFunction;
 import static com.google.common.collect.Lists.newArrayList;
 import static io.airlift.drift.codec.metadata.ThriftType.list;
 import static io.airlift.drift.codec.metadata.ThriftType.optional;
+import static java.net.InetAddress.getLoopbackAddress;
 import static java.util.Collections.nCopies;
 import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertEquals;
@@ -103,7 +105,7 @@ public class TestApacheThriftMethodInvoker
     private static int testProcessor(TProcessor processor, List<ToIntFunction<HostAndPort>> clients)
             throws Exception
     {
-        try (TServerSocket serverTransport = new TServerSocket(0)) {
+        try (TServerSocket serverTransport = new TServerSocket(new InetSocketAddress(getLoopbackAddress(), 0))) {
             TProtocolFactory protocolFactory = new Factory();
             TTransportFactory transportFactory = new TFramedTransport.Factory();
             TServer server = new TSimpleServer(new Args(serverTransport)
@@ -115,8 +117,9 @@ public class TestApacheThriftMethodInvoker
             try {
                 serverThread.start();
 
-                int localPort = serverTransport.getServerSocket().getLocalPort();
-                HostAndPort address = HostAndPort.fromParts("localhost", localPort);
+                String host = serverTransport.getServerSocket().getInetAddress().getHostAddress();
+                int port = serverTransport.getServerSocket().getLocalPort();
+                HostAndPort address = HostAndPort.fromParts(host, port);
 
                 int sum = 0;
                 for (ToIntFunction<HostAndPort> client : clients) {

--- a/drift-transport-netty/src/test/java/io/airlift/drift/transport/netty/client/TestDriftNettyMethodInvoker.java
+++ b/drift-transport-netty/src/test/java/io/airlift/drift/transport/netty/client/TestDriftNettyMethodInvoker.java
@@ -71,6 +71,7 @@ import org.apache.thrift.transport.TTransportFactory;
 import org.apache.thrift.transport.layered.TFramedTransport;
 import org.testng.annotations.Test;
 
+import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -89,6 +90,7 @@ import static io.airlift.drift.codec.metadata.ThriftType.list;
 import static io.airlift.drift.codec.metadata.ThriftType.optional;
 import static io.airlift.drift.transport.netty.codec.Protocol.BINARY;
 import static io.airlift.drift.transport.netty.codec.Transport.FRAMED;
+import static java.net.InetAddress.getLoopbackAddress;
 import static java.util.Collections.nCopies;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -147,7 +149,7 @@ public class TestDriftNettyMethodInvoker
     private static int testProcessor(TProcessor processor, List<ToIntFunction<HostAndPort>> clients)
             throws Exception
     {
-        try (TServerSocket serverTransport = new TServerSocket(0)) {
+        try (TServerSocket serverTransport = new TServerSocket(new InetSocketAddress(getLoopbackAddress(), 0))) {
             TProtocolFactory protocolFactory = new TBinaryProtocol.Factory();
             TTransportFactory transportFactory = new TFramedTransport.Factory();
             TServer server = new TSimpleServer(new Args(serverTransport)
@@ -159,8 +161,9 @@ public class TestDriftNettyMethodInvoker
             try {
                 serverThread.start();
 
-                int localPort = serverTransport.getServerSocket().getLocalPort();
-                HostAndPort address = HostAndPort.fromParts("localhost", localPort);
+                String host = serverTransport.getServerSocket().getInetAddress().getHostAddress();
+                int port = serverTransport.getServerSocket().getLocalPort();
+                HostAndPort address = HostAndPort.fromParts(host, port);
 
                 int sum = 0;
                 for (ToIntFunction<HostAndPort> client : clients) {


### PR DESCRIPTION
## Summary

- Bind Apache Thrift test servers to a specific loopback address.
- Connect test clients using the exact address selected by the server.

## Background

The Apache Thrift test servers enabled address reuse and bound to wildcard ephemeral ports, while clients separately resolved `localhost`. On macOS, this could select a port already used by a more specific IPv4 loopback listener. The client would then connect to the unrelated service and wait indefinitely for a Thrift response.

Binding and advertising the same loopback address prevents test traffic from being routed to an unrelated listener.